### PR TITLE
feat(jenkins): add Task 4 Helm chart and documentation for Jenkins on Minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,28 @@ This repository contains solutions for the RS School DevOps course tasks. Ea
 
 ---
 
+## Task 4 — **Jenkins on Kubernetes (Minikube)**
+
+*Goal:* deploy Jenkins via Helm on a local Minikube cluster, practise PVC/PV management and JCasC‑driven job definitions.
+
+**What was done**
+
+1. **Helm installation & verification** — 
+   * Helm v3 installed locally
+   * Bitnami Nginx chart deployed and removed to confirm setup.
+2. **Persistent storage** — Minikube add‑ons storage-provisioner & default-storageclass enabled.
+3. **Jenkins deployment** — official chart jenkinsci/jenkins installed in a dedicated namespace jenkins with a minimal values.yaml.
+4. **Hello‑world freestyle job** — produced via JCasC + Job DSL and prints Hello world to the build log.
+5. **Security** —
+   * local realm admin user and one extra user created.
+   * Hello‑world freestyle job via JCasC + Job DSL created
+
+---
+
 ## Structure
 
 ```
+jenkins/                    # Helm values & manifests for Task 4
 bootstrap/                  # one‑time remote‑state setup 
 terraform/                  # main Terraform configurations 
   ├─ *.tf                   # split into logical files
@@ -78,8 +97,16 @@ terraform apply -var-file=env/dev.tfvars
 terraform destroy -var-file=env/dev.tfvars
 ```
 
+### Task 4
+* Start local cluster (minikube)
+* Install Jenkins using official instruction
+* Use jenkins/jenkins-values.yaml for install settings
+
+
 ## Requirements
 
 * **Terraform ≥ 1.6**
 * **AWS CLI v2**
 * An AWS account with permissions to create the listed resources.
+* **Minikube ≥ 1.32 & kubectl**
+* **Helm ≥ 3.12**

--- a/jenkins/jenkins-01-volume.yaml
+++ b/jenkins/jenkins-01-volume.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jenkins-pv
+spec:
+  storageClassName: jenkins-pv
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 20Gi
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /data/jenkins-volume/
+    type: DirectoryOrCreate
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jenkins-pv
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/jenkins/jenkins-02-sa.yaml
+++ b/jenkins/jenkins-02-sa.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins
+  namespace: jenkins
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: jenkins
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - statefulsets
+  - services
+  - replicationcontrollers
+  - replicasets
+  - podtemplates
+  - podsecuritypolicies
+  - pods
+  - pods/log
+  - pods/exec
+  - podpreset
+  - poddisruptionbudget
+  - persistentvolumes
+  - persistentvolumeclaims
+  - jobs
+  - endpoints
+  - deployments
+  - deployments/scale
+  - daemonsets
+  - cronjobs
+  - configmaps
+  - namespaces
+  - events
+  - secrets
+  verbs:
+  - create
+  - get
+  - watch
+  - delete
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: jenkins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jenkins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:jenkins

--- a/jenkins/jenkins-values.yaml
+++ b/jenkins/jenkins-values.yaml
@@ -1,0 +1,33 @@
+controller:
+  serviceType: NodePort
+  nodePort: 32000
+
+  installPlugins:
+    - kubernetes
+    - workflow-aggregator
+    - git
+    - configuration-as-code
+    - job-dsl
+
+  JCasC:
+    enabled: true
+    configScripts:
+      hello-job-dsl: |
+        jobs:
+          - script: >
+              job('Hello World') {
+                  label('jenkins-jenkins-agent')
+                  steps {
+                      shell('echo "Hello world"')
+                  }
+              }
+
+persistence:
+  storageClass: jenkins-pv
+
+serviceAccount:
+  create: false
+  name: jenkins
+
+agent:
+  serviceAccountName: jenkins

--- a/jenkins/namespace.yaml
+++ b/jenkins/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins


### PR DESCRIPTION
1. **Helm Installation and Verification (10 points)**

   - Helm is installed and verified by deploying the Nginx chart.
   ![image](https://github.com/user-attachments/assets/08401b4f-d714-4c90-ac9c-b1b53fefa14f)
      <details>
      <summary>Show full log of helm verification</summary>
          
      ```bash
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm version
      version.BuildInfo{Version:"v3.18.2", GitCommit:"04cad4610054e5d546aa5c5d9c1b1d5cf68ec1f8", GitTreeState:"clean", GoVersion:"go1.24.3"}
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm repo list
      Error: no repositories to show
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm list
      NAME    NAMESPACE       REVISION        UPDATED STATUS  CHART   APP VERSION
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm repo add bitnami https://charts.bitnami.com/bitnami
      "bitnami" has been added to your repositories
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm install my-nginx bitnami/nginx --version 21.0.3
      NAME: my-nginx
      LAST DEPLOYED: Thu Jul  3 17:34:04 2025
      NAMESPACE: default
      STATUS: deployed
      REVISION: 1
      TEST SUITE: None
      NOTES:
      CHART NAME: nginx
      CHART VERSION: 21.0.3
      APP VERSION: 1.29.0
      
      Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami for more information.
      
      ** Please be patient while the chart is being deployed **
      NGINX can be accessed through the following DNS name from within your cluster:
      
          my-nginx.default.svc.cluster.local (port 80)
      
      To access NGINX from outside the cluster, follow the steps below:
      
      1. Get the NGINX URL by running these commands:
      
        NOTE: It may take a few minutes for the LoadBalancer IP to be available.
              Watch the status with: 'kubectl get svc --namespace default -w my-nginx'
      
          export SERVICE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].port}" services my-nginx)
          export SERVICE_IP=$(kubectl get svc --namespace default my-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
          echo "http://${SERVICE_IP}:${SERVICE_PORT}"
      
      WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
        - cloneStaticSiteFromGit.gitSync.resources
        - resources
      +info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm repo list
      NAME    URL
      bitnami https://charts.bitnami.com/bitnami
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm list
      NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
      my-nginx        default         1               2025-07-03 17:34:04.5661708 +0400 +04   deployed        nginx-21.0.3    1.29.0
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm uninstall my-nginx
      release "my-nginx" uninstalled
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm list
      NAME    NAMESPACE       REVISION        UPDATED STATUS  CHART   APP VERSION
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm repo remove bitnami
      "bitnami" has been removed from your repositories
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ helm repo list
      Error: no repositories to show
      Sergei@DESKTOP-PB3UKUP /c/cmder terminal
      λ
      
      ```
      </details>

2. **Cluster Requirements (10 points)**

   - The cluster has a solution for managing persistent volumes (PV) and persistent volume claims (PVC).
![image](https://github.com/user-attachments/assets/3440cd12-55b9-4ea7-82a8-135b5e90ccc2)


3. **Jenkins Installation (40 points)**

   - Jenkins is installed using Helm in a separate namespace.
![image](https://github.com/user-attachments/assets/d41e847e-7389-4951-893f-48925960de6a)

      <details>
      <summary>Show full log of Jenkins deploy</summary>
      
      ```bash
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ helm repo add jenkinsci https://charts.jenkins.io
      "jenkinsci" has been added to your repositories
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ helm repo update
      Hang tight while we grab the latest from your chart repositories...
      ...Successfully got an update from the "jenkinsci" chart repository
      Update Complete. ⎈Happy Helming!⎈
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ helm search repo jenkinsci
      NAME                    CHART VERSION   APP VERSION     DESCRIPTION
      jenkinsci/jenkins       5.8.65          2.504.3         Jenkins - Build great things at any scale! As t...
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl apply -f jenkins/namespace.yaml 
      namespace/jenkins created
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl apply -f jenkins/jenkins-01-volume.yaml
      persistentvolume/jenkins-pv created
      storageclass.storage.k8s.io/jenkins-pv created
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ minikube ssh
      docker@minikube:~$ sudo chown -R 1000:1000 /data/jenkins-volume
      docker@minikube:~$ exit
      logout
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl apply -f jenkins/jenkins-02-sa.yaml 
      serviceaccount/jenkins created
      clusterrole.rbac.authorization.k8s.io/jenkins created
      clusterrolebinding.rbac.authorization.k8s.io/jenkins created
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ helm install jenkins -n jenkins -f jenkins/jenkins-values.yaml jenkinsci/jenkins
      NAME: jenkins
      LAST DEPLOYED: Thu Jul  3 21:03:27 2025
      NAMESPACE: jenkins
      STATUS: deployed
      REVISION: 1
      NOTES:
      1. Get your 'admin' user password by running:
        kubectl exec --namespace jenkins -it svc/jenkins -c jenkins -- /bin/cat /run/secrets/additional/chart-admin-password && echo
      2. Get the Jenkins URL to visit by running these commands in the same shell:
        export NODE_PORT=$(kubectl get --namespace jenkins -o jsonpath="{.spec.ports[0].nodePort}" services jenkins)
        export NODE_IP=$(kubectl get nodes --namespace jenkins -o jsonpath="{.items[0].status.addresses[0].address}")
        echo http://$NODE_IP:$NODE_PORT
      
      3. Login with the password from step 1 and the username: admin
      4. Configure security realm and authorization strategy
      5. Use Jenkins Configuration as Code by specifying configScripts in your values.yaml file, see documentation: http://$NODE_IP:$NODE_PORT/configuration-as-code and examples: https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos
      
      For more information on running Jenkins on Kubernetes, visit:
      https://cloud.google.com/solutions/jenkins-on-container-engine
      
      For more information about Jenkins Configuration as Code, visit:
      https://jenkins.io/projects/jcasc/
      
      
      NOTE: Consider using a custom image with pre-installed plugins
      
      ```
      </details>

   - Jenkins is available from the web browser.
![image](https://github.com/user-attachments/assets/ef9c64b7-8ab7-46a7-bdb8-67035397d364)

4. **Jenkins Configuration (10 points)**

   - Jenkins configuration is stored on a persistent volume and is not lost when Jenkins' pod is terminated.
      <details>
      <summary>Show full log of pvc</summary>

      ```bash
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl get pvc -n jenkins
      NAME      STATUS   VOLUME       CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
      jenkins   Bound    jenkins-pv   20Gi       RWO            jenkins-pv     <unset>                 59m
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl delete pod jenkins-0 -n jenkins
      pod "jenkins-0" deleted
      
      Sergei@DESKTOP-PB3UKUP MINGW64 /c/EdProject/rsschool-devops-course-tasks (task_4)
      $ kubectl get pvc -n jenkins
      NAME      STATUS   VOLUME       CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
      jenkins   Bound    jenkins-pv   20Gi       RWO            jenkins-pv     <unset>                 60m
      ```
      </details>

5. **Verification (15 points)**

   - A simple Jenkins freestyle project is created and runs successfully, writing "Hello world" into the log.
![image](https://github.com/user-attachments/assets/41f61c82-52a5-4ef2-bdcb-382f9789ec47)
      <details>
      <summary>Show full log of Jenkins job</summary>
      
      ```bash
      Started by user Jenkins Admin
      Running as SYSTEM
      Agent default-zzfkn is provisioned from template default
      ---
      apiVersion: "v1"
      kind: "Pod"
      metadata:
        annotations:
          kubernetes.jenkins.io/last-refresh: "1751752452143"
        labels:
          jenkins/jenkins-jenkins-agent: "true"
          jenkins/label-digest: "500b4f18aee87616849e4f4c2435020898e34aa0"
          jenkins/label: "jenkins-jenkins-agent"
          kubernetes.jenkins.io/controller: "http___jenkins_jenkins_svc_cluster_local_8080x"
        name: "default-zzfkn"
        namespace: "jenkins"
      spec:
        containers:
        - args:
          - "********"
          - "default-zzfkn"
          env:
          - name: "JENKINS_SECRET"
            value: "********"
          - name: "JENKINS_TUNNEL"
            value: "jenkins-agent.jenkins.svc.cluster.local:50000"
          - name: "JENKINS_AGENT_NAME"
            value: "default-zzfkn"
          - name: "REMOTING_OPTS"
            value: "-noReconnectAfter 1d"
          - name: "JENKINS_NAME"
            value: "default-zzfkn"
          - name: "JENKINS_AGENT_WORKDIR"
            value: "/home/jenkins/agent"
          - name: "JENKINS_URL"
            value: "http://jenkins.jenkins.svc.cluster.local:8080/"
          image: "jenkins/inbound-agent:3309.v27b_9314fd1a_4-7"
          imagePullPolicy: "IfNotPresent"
          name: "jnlp"
          resources:
            limits:
              memory: "512Mi"
              cpu: "512m"
            requests:
              memory: "512Mi"
              cpu: "512m"
          tty: false
          volumeMounts:
          - mountPath: "/home/jenkins/agent"
            name: "workspace-volume"
            readOnly: false
          workingDir: "/home/jenkins/agent"
        nodeSelector:
          kubernetes.io/os: "linux"
        restartPolicy: "Never"
        serviceAccountName: "default"
        volumes:
        - emptyDir:
            medium: ""
          name: "workspace-volume"
      
      Building remotely on default-zzfkn (jenkins-jenkins-agent) in workspace /home/jenkins/agent/workspace/Hello World
      [Hello World] $ /bin/sh -xe /tmp/jenkins11094222259862798930.sh
      + echo Hello world
      Hello world
      Finished: SUCCESS
      ```
      </details>

6. **Additional Tasks (15 points)💫**
   - **GitHub Actions (GHA) Pipeline (5 points)**
     - A GHA pipeline is set up to deploy Jenkins. 
     According to the information from the webinar, we receive 5 points by default
   - **Authentication and Security (5 points)**
     - Authentication and security settings are configured for Jenkins.

     **Please let me know if I have misunderstood this point.**

![image](https://github.com/user-attachments/assets/39bb6458-d58a-4535-ab50-b0e29d520fef)
   - **JCasC is used to describe job in Jenkins (5 points)**
     - "Hello World" job is created via JCasC in [HELM chart values](https://github.com/Srmrlt/rsschool-devops-course-tasks/blob/task_4/jenkins/jenkins-values.yaml).